### PR TITLE
Sync deletions for task-list and task documents

### DIFF
--- a/sync-gateway-config.json
+++ b/sync-gateway-config.json
@@ -97,9 +97,9 @@ function(doc, oldDoc){
   } else if (getType() == "task") {
     /* Write Access */
     var owner = doc._deleted ? oldDoc.taskList.owner : doc.taskList.owner;
-    var list = doc._deleted ? oldDoc.taskList.id : doc.taskList.id;
+    var listId = doc._deleted ? oldDoc.taskList.id : doc.taskList.id;
     try {
-      requireAccess("task-list." + list);
+      requireAccess("task-list." + listId);
     } catch (e) {
       requireUser(owner);
     }
@@ -124,7 +124,7 @@ function(doc, oldDoc){
 
     /* Route */
     // Add doc to task-list and moderators channel.
-    channel("task-list." + list);
+    channel("task-list." + listId);
     channel("moderators");
   } else if (getType() == "task-list.user") {
     /* Control Write Access */
@@ -162,14 +162,14 @@ function(doc, oldDoc){
 
     /* Route */
     // Add doc to task-list users and moderators channel.
-    var list = doc._deleted ? oldDoc.taskList.id : doc.taskList.id;
-    channel("task-list." + list + ".users");
+    var listId = doc._deleted ? oldDoc.taskList.id : doc.taskList.id;
+    channel("task-list." + listId + ".users");
     channel("moderators");
 
     /* Grant Read Access */
     // Grant the user access to the task-list and its tasks.
     if (!isDelete()) {
-      access(doc.username, "task-list." + list);
+      access(doc.username, "task-list." + listId);
     }
   } else {
     // Log invalid document type error.

--- a/sync-gateway-config.json
+++ b/sync-gateway-config.json
@@ -61,14 +61,13 @@ function(doc, oldDoc){
     access(doc.username, doc.username);
   } else if (getType() == "task-list") {
     /* Control Write Access */
-    if (isCreate()) {
-      try {
-        // Users can create/update lists for themselves.
-        requireUser(doc.owner);
-      } catch (e) {
-        // Moderators can create/update lists for other users.
-        requireRole("moderator");
-      }
+    var owner = doc._deleted ? oldDoc.owner : doc.owner;
+    try {
+      // Users can create/update lists for themselves.
+      requireUser(owner);
+    } catch (e) {
+      // Moderators can create/update lists for other users.
+      requireRole("moderator");
     }
 
     /* Validate */
@@ -97,10 +96,12 @@ function(doc, oldDoc){
     access(doc.owner, "task-list." + doc._id + ".users");
   } else if (getType() == "task") {
     /* Write Access */
+    var owner = doc._deleted ? oldDoc.taskList.owner : doc.taskList.owner;
+    var list = doc._deleted ? oldDoc.taskList.id : doc.taskList.id;
     try {
-      requireAccess("task-list." + doc.taskList.id);
+      requireAccess("task-list." + list);
     } catch (e) {
-      requireUser(doc.taskList.owner);
+      requireUser(owner);
     }
 
     /* Validate */
@@ -123,7 +124,7 @@ function(doc, oldDoc){
 
     /* Route */
     // Add doc to task-list and moderators channel.
-    channel("task-list." + doc.taskList.id);
+    channel("task-list." + list);
     channel("moderators");
   } else if (getType() == "task-list.user") {
     /* Control Write Access */

--- a/sync-gateway-config.json
+++ b/sync-gateway-config.json
@@ -96,7 +96,9 @@ function(doc, oldDoc){
     access(doc.owner, "task-list." + doc._id + ".users");
   } else if (getType() == "task") {
     /* Write Access */
-    validateNotEmpty("taskList", doc.taskList);
+    if (!isDelete()) {
+      validateNotEmpty("taskList", doc.taskList);
+    }
     var owner = doc._deleted ? oldDoc.taskList.owner : doc.taskList.owner;
     var listId = doc._deleted ? oldDoc.taskList.id : doc.taskList.id;
     try {
@@ -129,7 +131,9 @@ function(doc, oldDoc){
     channel("moderators");
   } else if (getType() == "task-list.user") {
     /* Control Write Access */
-    validateNotEmpty("taskList", doc.taskList);
+    if (!isDelete()) {
+      validateNotEmpty("taskList", doc.taskList);
+    }
     var owner = doc._deleted ? oldDoc.taskList.owner : doc.taskList.owner;
     try {
       requireUser(owner);

--- a/sync-gateway-config.json
+++ b/sync-gateway-config.json
@@ -96,6 +96,7 @@ function(doc, oldDoc){
     access(doc.owner, "task-list." + doc._id + ".users");
   } else if (getType() == "task") {
     /* Write Access */
+    validateNotEmpty("taskList", doc.taskList);
     var owner = doc._deleted ? oldDoc.taskList.owner : doc.taskList.owner;
     var listId = doc._deleted ? oldDoc.taskList.id : doc.taskList.id;
     try {
@@ -128,6 +129,7 @@ function(doc, oldDoc){
     channel("moderators");
   } else if (getType() == "task-list.user") {
     /* Control Write Access */
+    validateNotEmpty("taskList", doc.taskList);
     var owner = doc._deleted ? oldDoc.taskList.owner : doc.taskList.owner;
     try {
       requireUser(owner);


### PR DESCRIPTION
The issue observed here was that deletion revisions were rejected by the Sync Function because they were missing the `type` property. https://github.com/couchbaselabs/mobile-training-todo/pull/23 added the `getType` method to account for that. This PR adds a few checks for write permissions and routing when doc is a deletion revision.

Changes:
- Write permissions (task-list & task): Take `owner` and `taskList.id` from oldDoc if doc is a deletion revision.
- Routing (task): Take `taskList.id` from oldDoc if doc is a deletion revision.

@adamcfraser Can you take a look at this one when you have a moment. Similarly to https://github.com/couchbaselabs/mobile-training-todo/pull/23#discussion_r85786655, I'll keep an eye on the scenario where oldDoc and doc are both deletion revisions.

Fix #20