### PR TITLE
Fixed #108 - Image attachment not sync'ing from .NET to Android

### DIFF
--- a/android/app/src/main/java/com/couchbase/todo/TasksFragment.java
+++ b/android/app/src/main/java/com/couchbase/todo/TasksFragment.java
@@ -128,7 +128,8 @@ public class TasksFragment extends Fragment {
                         ArrayList<String> key = new ArrayList<String>();
                         key.add(listId);
                         key.add(task);
-                        emitter.emit(key, null);
+                        String value = (String) document.get("_rev");
+                        emitter.emit(key, value);
                     }
                 }
             }, "5.0");


### PR DESCRIPTION
CBL Android has known implementation difference between ForestDB and SQLite. SQLite: emit(key, null) always sends notification. ForestDB: emit(key, null) sends notification if key and value is different from previous emit. ToDo’s task’s emit same key and value always. And it does not send notification.