### PR TITLE
image picking permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,8 @@
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.READ_PROFILE" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
-
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET"/>
 


### PR DESCRIPTION
Starting with API level 23, permissions must now be requested while the app is running rather than prior to installation. We can't add the READ_EXTERNAL_STORAGE permission to AndroidManifest.xml anymore (used for image picking) and must do it in code when the user is about to select perform that action. This change prompts the user for that permission when the camera icon is clicked for the first time.

fix #115