### PR TITLE
Removing obselete replicator_2 configuration from Sync Gateway config

### DIFF
--- a/swift/sync-gateway-config.json
+++ b/swift/sync-gateway-config.json
@@ -14,9 +14,6 @@
         "moderator": {},
         "admin": {}
       },
-      "unsupported": {
-        "replicator_2":true
-      },
       "sync": `
 function(doc, oldDoc){
   /* Type validation */


### PR DESCRIPTION
Hi Pasin,

Please review this for removing the replicator_2 configuration from Sync Gateway config.