### PR TITLE
Remove obsolete property from Couchbase Sync Gateway configuration

### DIFF
--- a/objc/sync-gateway-config.json
+++ b/objc/sync-gateway-config.json
@@ -15,9 +15,6 @@
         "moderator": {},
         "admin": {}
       },
-      "unsupported": {
-        "replicator_2":true
-      },
       "sync": `
 function(doc, oldDoc){
   /* Type validation */


### PR DESCRIPTION
We need to remove the unsupported replicator_2 property from Couchbase Sync Gateway configuration