### PR TITLE
feat: task detail page

### DIFF
--- a/swift/Todo.xcodeproj/project.pbxproj
+++ b/swift/Todo.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1A52D218260AEA1E00A9BEBD /* CouchbaseLiteSwift.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A52D216260AEA1700A9BEBD /* CouchbaseLiteSwift.xcframework */; };
 		1A52D219260AEA1E00A9BEBD /* CouchbaseLiteSwift.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1A52D216260AEA1700A9BEBD /* CouchbaseLiteSwift.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		1A52D21D260B0FCF00A9BEBD /* TaskDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A52D21C260B0FCF00A9BEBD /* TaskDetailViewController.swift */; };
 		932EA5E02065D59300EDB667 /* Fabric.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 932EA5DE2065D59300EDB667 /* Fabric.framework */; };
 		932EA5E12065D59300EDB667 /* Crashlytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 932EA5DF2065D59300EDB667 /* Crashlytics.framework */; };
 		933F1AB81F393EEE00338C6A /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933F1AB71F393EEE00338C6A /* Constants.swift */; };
@@ -56,6 +57,7 @@
 
 /* Begin PBXFileReference section */
 		1A52D216260AEA1700A9BEBD /* CouchbaseLiteSwift.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CouchbaseLiteSwift.xcframework; path = Frameworks/CouchbaseLiteSwift.xcframework; sourceTree = "<group>"; };
+		1A52D21C260B0FCF00A9BEBD /* TaskDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetailViewController.swift; sourceTree = "<group>"; };
 		932EA5DE2065D59300EDB667 /* Fabric.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Fabric.framework; path = Frameworks/Fabric.framework; sourceTree = "<group>"; };
 		932EA5DF2065D59300EDB667 /* Crashlytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Crashlytics.framework; path = Frameworks/Crashlytics.framework; sourceTree = "<group>"; };
 		933F1AB71F393EEE00338C6A /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
@@ -169,6 +171,7 @@
 				93D9D9AD1EDF8495001355EE /* LoginViewController.swift */,
 				934646BB1C69CF6B002F52C9 /* TasksViewController.swift */,
 				934646C51C6B218D002F52C9 /* TaskImageViewController.swift */,
+				1A52D21C260B0FCF00A9BEBD /* TaskDetailViewController.swift */,
 				93D6508D1EF441DE00EA44F3 /* UsersViewController.swift */,
 				933F1AB71F393EEE00338C6A /* Constants.swift */,
 				93D9D9AB1EDF8427001355EE /* Session.swift */,
@@ -318,6 +321,7 @@
 				9382586B21632B46006A75AD /* QE.swift in Sources */,
 				934646C61C6B218D002F52C9 /* TaskImageViewController.swift in Sources */,
 				93F4B2E01C696C78005FF4D8 /* Ui.swift in Sources */,
+				1A52D21D260B0FCF00A9BEBD /* TaskDetailViewController.swift in Sources */,
 				939279F81C72E9C8009D9A92 /* Image.swift in Sources */,
 				93D999FD1C7FE78300FEFF17 /* TextDialog.swift in Sources */,
 				93D9D9AE1EDF8495001355EE /* LoginViewController.swift in Sources */,

--- a/swift/Todo/AppDelegate.swift
+++ b/swift/Todo/AppDelegate.swift
@@ -17,7 +17,7 @@ import Crashlytics
 let kLoggingEnabled = true
 let kLoginFlowEnabled = true
 let kSyncEnabled = true
-let kSyncEndpoint = "ws://ec2-3-90-70-164.compute-1.amazonaws.com:4984/todo"
+let kSyncEndpoint = "ws://localhost:4984/todo"
 let kSyncWithPushNotification = true
 
 // Custom conflict resolver

--- a/swift/Todo/Base.lproj/Main.storyboard
+++ b/swift/Todo/Base.lproj/Main.storyboard
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="Cmk-JT-Nca">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="Cmk-JT-Nca">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -14,7 +15,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="xqs-l8-eBI">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="TaskListCell" textLabel="TzV-EG-pVw" detailTextLabel="qYa-Xj-y2d" style="IBUITableViewCellStyleValue1" id="qmj-7m-Bw6">
                                 <rect key="frame" x="0.0" y="28" width="375" height="44"/>
@@ -31,7 +32,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="qYa-Xj-y2d">
-                                            <rect key="frame" x="298.5" y="13" width="41.5" height="19.5"/>
+                                            <rect key="frame" x="298" y="13" width="42" height="19.5"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                             <color key="textColor" red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -73,13 +74,13 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="64" sectionHeaderHeight="28" sectionFooterHeight="28" id="X5Z-ka-Tzf">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="checkmark" indentationWidth="10" reuseIdentifier="TaskCell" id="qgp-S5-5Hv" customClass="TaskTableViewCell" customModule="Todo" customModuleProvider="target">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="TaskCell" id="qgp-S5-5Hv" customClass="TaskTableViewCell" customModule="Todo" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="28" width="375" height="64"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="qgp-S5-5Hv" id="ks4-9v-gfR">
-                                    <rect key="frame" x="0.0" y="0.0" width="335" height="64"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="348" height="64"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mfJ-5J-Z5v">
@@ -94,7 +95,7 @@
                                             </connections>
                                         </button>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Nc-1H-Yn9">
-                                            <rect key="frame" x="74" y="21.5" width="251" height="21"/>
+                                            <rect key="frame" x="74" y="21.5" width="264" height="21"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="21" id="twg-34-LcY"/>
                                             </constraints>
@@ -133,6 +134,7 @@
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
                         <segue destination="FxE-I0-R1m" kind="modal" identifier="showTaskImage" id="zlz-mt-6US"/>
+                        <segue destination="JCk-TT-EFQ" kind="modal" identifier="showTaskDetail" id="zIY-fA-2s9"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="8AM-cn-lzV" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -247,7 +249,7 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BNK-23-zuD">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BNK-23-zuD">
                                 <rect key="frame" x="87.5" y="212" width="200" height="30"/>
                                 <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
@@ -328,7 +330,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="cWD-Ya-uIh">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="UserCell" textLabel="43Z-mM-N08" style="IBUITableViewCellStyleDefault" id="MbR-Es-14H">
                                 <rect key="frame" x="0.0" y="28" width="375" height="44"/>
@@ -358,11 +360,150 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="1BN-U9-bVT" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2223.1884057971015" y="1022.5446428571428"/>
+            <point key="canvasLocation" x="2222" y="1440"/>
+        </scene>
+        <!--Task Detail View Controller-->
+        <scene sceneID="DQX-5c-Hb3">
+            <objects>
+                <viewController id="sha-l2-7Vc" customClass="TaskDetailViewController" customModule="Todo" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="alQ-O6-fR1"/>
+                        <viewControllerLayoutGuide type="bottom" id="2xy-x0-LoG"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="o4f-bQ-clt">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="ki6-h4-NHW">
+                                <rect key="frame" x="16" y="66" width="343" height="581"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="260" verticalCompressionResistancePriority="800" text="TaskName" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4lf-va-lqa">
+                                        <rect key="frame" x="0.0" y="0.0" width="343" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="260" translatesAutoresizingMaskIntoConstraints="NO" id="53D-fR-wjw">
+                                        <rect key="frame" x="0.0" y="40.5" width="343" height="20.5"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Complete:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HFD-nJ-DKe">
+                                                <rect key="frame" x="0.0" y="0.0" width="294" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Afv-G0-wpY">
+                                                <rect key="frame" x="294" y="0.0" width="51" height="20.5"/>
+                                                <connections>
+                                                    <action selector="switchChanged:" destination="sha-l2-7Vc" eventType="valueChanged" id="URq-Iw-IKm"/>
+                                                </connections>
+                                            </switch>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="4uP-K4-eZo">
+                                        <rect key="frame" x="0.0" y="81" width="343" height="34"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Bbz-2j-cz5">
+                                                <rect key="frame" x="0.0" y="0.0" width="303" height="34"/>
+                                                <subviews>
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Add New Key" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="eD8-81-2JO">
+                                                        <rect key="frame" x="0.0" y="0.0" width="149" height="34"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <textInputTraits key="textInputTraits"/>
+                                                    </textField>
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Add New Value" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="F9y-Ch-P2P">
+                                                        <rect key="frame" x="154" y="0.0" width="149" height="34"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <textInputTraits key="textInputTraits"/>
+                                                    </textField>
+                                                </subviews>
+                                            </stackView>
+                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="300" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AiI-Uj-mMZ">
+                                                <rect key="frame" x="313" y="0.0" width="30" height="34"/>
+                                                <state key="normal" title="Set"/>
+                                                <connections>
+                                                    <action selector="setKeyValue:" destination="sha-l2-7Vc" eventType="touchUpInside" id="ata-C1-PG2"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                    </stackView>
+                                    <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="XJV-eG-K8M">
+                                        <rect key="frame" x="0.0" y="135" width="343" height="32"/>
+                                        <segments>
+                                            <segment title="Dictionary"/>
+                                            <segment title="JSON"/>
+                                        </segments>
+                                        <connections>
+                                            <action selector="segmentedControlValueChanged:" destination="sha-l2-7Vc" eventType="valueChanged" id="bYS-iC-rlG"/>
+                                        </connections>
+                                    </segmentedControl>
+                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="hzf-RZ-7Pl">
+                                        <rect key="frame" x="0.0" y="186" width="343" height="395"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
+                                        <color key="textColor" systemColor="labelColor"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                    </textView>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="ki6-h4-NHW" firstAttribute="leading" secondItem="o4f-bQ-clt" secondAttribute="leadingMargin" id="7nW-gw-CYr"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="ki6-h4-NHW" secondAttribute="trailing" id="AXd-vC-dvw"/>
+                            <constraint firstItem="2xy-x0-LoG" firstAttribute="top" secondItem="ki6-h4-NHW" secondAttribute="bottom" id="piL-ru-hsa"/>
+                            <constraint firstItem="ki6-h4-NHW" firstAttribute="top" secondItem="alQ-O6-fR1" secondAttribute="bottom" constant="10" id="x13-rA-3Eb"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="mPw-ss-2SJ">
+                        <barButtonItem key="leftBarButtonItem" title="Close" id="Yqn-jw-uh2">
+                            <connections>
+                                <action selector="closeAction:" destination="sha-l2-7Vc" id="dyV-Xo-Kfg"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <connections>
+                        <outlet property="completeSwitch" destination="Afv-G0-wpY" id="aFj-Ol-WWS"/>
+                        <outlet property="keyTextField" destination="eD8-81-2JO" id="9fh-Kt-BA7"/>
+                        <outlet property="segmentedControl" destination="XJV-eG-K8M" id="y2g-uq-fNQ"/>
+                        <outlet property="taskName" destination="4lf-va-lqa" id="eR0-l1-kwO"/>
+                        <outlet property="textView" destination="hzf-RZ-7Pl" id="zRf-bN-GI8"/>
+                        <outlet property="valueTextField" destination="F9y-Ch-P2P" id="9dE-fC-ehF"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="0P8-fT-R77" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4673" y="1440"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="jzi-uh-DwU">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="JCk-TT-EFQ" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationItem key="navigationItem" id="pvA-2D-y1I"/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="bKc-X9-tUL">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="sha-l2-7Vc" kind="relationship" relationship="rootViewController" id="nWw-2a-ZNC"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="F5D-nj-4MS" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3857" y="1439"/>
         </scene>
     </scenes>
     <resources>
         <image name="Tasks" width="28" height="28"/>
         <image name="Users" width="28" height="28"/>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/swift/Todo/TaskDetailViewController.swift
+++ b/swift/Todo/TaskDetailViewController.swift
@@ -1,0 +1,70 @@
+//
+//  TaskDetailViewController.swift
+//  Todo
+//
+//  Created by Jayahari Vavachan on 3/23/21.
+//  Copyright © 2021 Couchbase. All rights reserved.
+//
+
+import UIKit
+import CouchbaseLiteSwift
+
+class TaskDetailViewController: UIViewController {
+    var taskID: String!
+    var task: Document!
+    var database: Database!
+    
+    @IBOutlet var taskName: UILabel!
+    @IBOutlet var completeSwitch: UISwitch!
+    @IBOutlet var segmentedControl: UISegmentedControl!
+    @IBOutlet var textView: UITextView!
+    @IBOutlet var keyTextField: UITextField!
+    @IBOutlet var valueTextField: UITextField!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        let app = UIApplication.shared.delegate as! AppDelegate
+        database = app.database
+        task = database.document(withID: taskID)!
+        
+        updateUI()
+    }
+    
+    @IBAction func closeAction(_ sender: AnyObject) {
+        dismiss(animated: true, completion: nil)
+    }
+
+    @IBAction func segmentedControlValueChanged(_ sender: Any) {
+        updateUI()
+    }
+    @IBAction func switchChanged(_ sender: Any) {
+        updateTask((sender as! UISwitch).isOn, forKey: "complete")
+    }
+    
+    @IBAction func setKeyValue(_ sender: Any) {
+        guard let key = keyTextField.text,
+              let value = valueTextField.text else {
+            return
+        }
+        
+        updateTask(value, forKey: key)
+    }
+    
+    func updateTask(_ value: Any, forKey key: String) {
+        let mutableTask = task.toMutable()
+        mutableTask.setValue(value, forKey: key)
+        try! database.saveDocument(mutableTask)
+        
+        task = database.document(withID: taskID)
+        updateUI()
+    }
+    
+    func updateUI() {
+        completeSwitch.isOn = task.boolean(forKey: "complete")
+        
+        taskName.text = task.string(forKey: "task")
+        textView.text = segmentedControl.selectedSegmentIndex == 0
+            ? "\(task.toDictionary())" : "\(task.toJSON())" 
+    }
+}

--- a/swift/Todo/TasksViewController.swift
+++ b/swift/Todo/TasksViewController.swift
@@ -377,6 +377,7 @@ class TasksViewController: UITableViewController, UISearchResultsUpdating, UISea
             self.taskIDForImage = row.string(at: 0)!
             self.performSegue(withIdentifier: "showTaskDetail", sender: self)
         }
+        detail.backgroundColor = UIColor(red: 0.0, green: 1.0, blue: 0.0, alpha: 1.0)
         
         return [delete, update, log, detail]
     }

--- a/swift/Todo/TasksViewController.swift
+++ b/swift/Todo/TasksViewController.swift
@@ -275,8 +275,8 @@ class TasksViewController: UITableViewController, UISearchResultsUpdating, UISea
         let docID = result.string(at: 0)!
         cell.taskLabel.text = result.string(at: 1)!
         
-        let complete: Bool = result.boolean(at: 2)
-        cell.accessoryType = complete ? .checkmark : .none
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .none
         
         if let imageBlob = result.blob(at: 3) {
             let digest = imageBlob.digest!
@@ -320,15 +320,9 @@ class TasksViewController: UITableViewController, UISearchResultsUpdating, UISea
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let row = self.data![indexPath.row]
-        let docID = row.string(at: 0)!
-        let doc = database.document(withID: docID)!
+        taskIDForImage = row.string(at: 0)!
         
-        let complete: Bool = !doc.boolean(forKey: "complete")
-        updateTask(taskID: docID, withComplete: complete)
-        
-        // Optimistically update the UI:
-        let cell = tableView.cellForRow(at: indexPath) as! TaskTableViewCell
-        cell.accessoryType = complete ? .checkmark : .none
+        self.performSegue(withIdentifier: "showTaskDetail", sender: self)
     }
     
     override func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
@@ -405,6 +399,11 @@ class TasksViewController: UITableViewController, UISearchResultsUpdating, UISea
         if segue.identifier == "showTaskImage" {
             let navController = segue.destination as! UINavigationController
             let controller = navController.topViewController as! TaskImageViewController
+            controller.taskID = taskIDForImage
+            taskIDForImage = nil
+        } else if segue.identifier == "showTaskDetail" {
+            let navController = segue.destination as! UINavigationController
+            let controller = navController.topViewController as! TaskDetailViewController
             controller.taskID = taskIDForImage
             taskIDForImage = nil
         }


### PR DESCRIPTION
* Click on the task to get to this page 
* add task detail page with segmented control for choosing to-(dictionary/json)
* add more key-values to the document
* complete/not-complete switch

<img width="388" alt="Screen Shot 2021-03-25 at 6 27 38 PM" src="https://user-images.githubusercontent.com/10448770/112564126-e961a200-8d97-11eb-925c-77c370af990a.png">
<img width="389" alt="Screen Shot 2021-03-25 at 6 27 44 PM" src="https://user-images.githubusercontent.com/10448770/112564135-ee265600-8d97-11eb-8006-9e45c3c8a376.png">
