### PR TITLE
Implement startReplicator() in AppLogic-C.swift

### DIFF
--- a/config/walrus.json
+++ b/config/walrus.json
@@ -1,0 +1,85 @@
+{
+    "disable_persistent_config": true,
+    "logging": {
+      "console": {
+        "log_keys": ["*"]
+      }
+    },
+    "databases": {
+        "todo": {
+            "server": "walrus:",
+            "users": {
+                "user1": {
+                    "password": "pass", 
+                    "collection_access": {
+                        "_default": {
+                            "lists": {"admin_channels": [] },
+                            "tasks": {"admin_channels": []},
+                            "users": {"admin_channels": []} 
+                        }
+                    }
+                },
+                "user2": {
+                    "password": "pass", 
+                    "collection_access": {
+                        "_default": {
+                            "lists": {"admin_channels": [ ]},
+                            "tasks": {"admin_channels": [ ]},
+                            "users": {"admin_channels": [ ]} 
+                        }
+                    }
+                }
+            },
+            "scopes": {
+                "_default": {
+                    "collections": {
+                        "lists": { 
+                            "sync": 
+`
+function(doc, oldDoc) {
+    var owner = doc._deleted ? oldDoc.owner : doc.owner;
+    requireUser(owner);
+
+    var listChannel = "task-list." + doc._id;
+    access(owner, listChannel);
+    channel(listChannel);
+}
+`
+                        },
+                        "tasks": { 
+                            "sync": 
+`
+function(doc, oldDoc) {
+    var owner = doc._deleted ? oldDoc.taskList.owner : doc.taskList.owner;
+    requireUser(owner);
+
+    var listId = doc._deleted ? oldDoc.taskList.id : doc.taskList.id;
+    var listChannel = "task-list." + listId;
+    var tasksChannel = listChannel + ".tasks";
+    access(owner, tasksChannel);
+    channel(tasksChannel);
+}
+`
+                        },
+                        "users": { 
+                            "sync": 
+`
+function(doc, oldDoc) {
+    var owner = doc._deleted ? oldDoc.taskList.owner : doc.taskList.owner;
+    requireUser(owner);
+
+    var listId = doc._deleted ? oldDoc.taskList.id : doc.taskList.id;
+    var listChannel = "task-list." + listId;
+    var usersChannel = listChannel + ".users";
+    access(owner, usersChannel);
+    channel(usersChannel);
+}
+`
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+  

--- a/swift/Todo/Model/AppLogic-C-Support.swift
+++ b/swift/Todo/Model/AppLogic-C-Support.swift
@@ -86,13 +86,6 @@ extension FLSlice {
         return NSString(bytes: buf, length: self.size, encoding: NSUTF8StringEncoding)! as String
     }
     
-    // For some reason, Swift converts any const FLString such as kCBLDefaultScopeName to NSString!.
-    // Use this function to convert those to String.
-    func constString() -> String {
-        guard let buf = self.buf else { fatalError("Invalid string") }
-        return Unmanaged<NSString>.fromOpaque(buf).takeUnretainedValue() as String
-    }
-    
     func asData() -> Data? {
         guard let buf = self.buf else { return nil }
         return Data.init(bytes: buf, count: self.size)


### PR DESCRIPTION
* Implemented startReplicator() in AppLogic-C.swift
* Added config.walrus.json for starting Sync-Gateway in walrun mode. Note that the Sync Functions do not support sharing task lists with other users yet.
* Removed FLSlice.constString() -> String
* Required CBL-C 3.1.0-350 (RC2)